### PR TITLE
v2.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v2.6.0](https://github.com/MyAlbum/sheet-modal/releases/tag/v2.6.0)
+### Summary
+Added a prop to render the modal in a different portal
+### Added
+- `portalHostName` prop to render in a different portal
+### Fixed
+- Crash on native when triggering `onSnapPointChanged`
+
 ## [v2.5.0](https://github.com/MyAlbum/sheet-modal/releases/tag/v2.5.0)
 ### Summary
 Added `portal` export

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -5,4 +5,4 @@
 - Bump the version according to the changes. `yarn version-<major|minor|patch>` or `yarn version-rc` for release candidates.
 - Create and merge a pull request to `main` with the changes.
 - Create a new release on GitHub with the version number.
-- After the release is merged to `main`, the build will run and a release will be automatically published to npm.
+- After the release published, the build will run and a release will be automatically published to npm and GitHub.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@myalbum/sheet-modal",
-  "version": "2.5.0",
+  "version": "2.6.0",
   "description": "An interactive sheet modal, fully customizable & performance focused",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",

--- a/src/components/ModalInstance.tsx
+++ b/src/components/ModalInstance.tsx
@@ -43,7 +43,7 @@ const SheetModalInstance = forwardRef<SheetModalMethods, SheetModalWithChildren>
   }
 
   return (
-    <PortalComponent>
+    <PortalComponent host={props.portalHostName ?? 'default'}>
       <WindowContext.Provider value={windowDimensions}>
         <SheetModalContext.Provider value={store}>
           <SheetModalBackdrop />

--- a/src/hooks/usePan.ts
+++ b/src/hooks/usePan.ts
@@ -175,7 +175,9 @@ function usePan(panConfig: PanConfig) {
           }
 
           if (newSnapPointIndex !== currentSnapPointIndex) {
-            store.config.value.onSnapPointChanged?.(newSnapPointIndex);
+            if (store.config.value.onSnapPointChanged) {
+              runOnJS(store.config.value.onSnapPointChanged)(newSnapPointIndex);
+            }
           }
 
           isFinishingPan.value = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,12 @@ export type SheetModalConfig = {
   panDownToClose: boolean;
 
   /**
+   * Name of the portal host to use
+   * Defaults to "default"
+   */
+  portalHostName?: string;
+
+  /**
    * Trap focus inside the sheet modal
    * Defaults to true
    */
@@ -111,6 +117,12 @@ export type SheetModalConfig = {
    * Defaults to true
    */
   withClosebutton: boolean;
+
+  /**
+   * Render a backdrop behind the sheet modal
+   * Defaults to true
+   */
+  withBackdrop: boolean;
 
   /**
    * Render a custom handle component
@@ -141,12 +153,6 @@ export type SheetModalConfig = {
    * Callback when the sheet modal has changes snap point
    */
   onSnapPointChanged?: (index: number) => void;
-
-  /**
-   * Render a backdrop behind the sheet modal
-   * Defaults to true
-   */
-  withBackdrop: boolean;
 };
 
 export type SheetModalMethods = {


### PR DESCRIPTION
### Summary
Added a prop to render the modal in a different portal
### Added
- `portalHostName` prop to render in a different portal
### Fixed
- Crash on native when triggering `onSnapPointChanged`